### PR TITLE
Pin uv Docker image to version tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apt update && apt install -y \
   libglib2.0-0 \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17 /uv /usr/local/bin/uv
 
 COPY uv.lock pyproject.toml ./
-RUN uv sync --no-dev --no-install-project
+RUN uv sync --frozen --no-dev --no-install-project
 
 COPY . .


### PR DESCRIPTION
## Summary
- Pins `ghcr.io/astral-sh/uv:latest` to `uv:0.11.17` to avoid supply chain risk from a floating tag
- Adds `--frozen` to `uv sync` so builds fail fast if `uv.lock` is out of date

## Test plan
- [ ] CI passes (test + lint + build jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)